### PR TITLE
updating scripts for setting up new machine

### DIFF
--- a/dev-tools-setup.sh
+++ b/dev-tools-setup.sh
@@ -16,7 +16,9 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     brew install curl
     brew install tree
     brew install spaceship
-
+    brew install mongosh
+    brew install withgraphite/tap/graphite # TODO: Find out if it's useful
+    
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
 else

--- a/install-apps.sh
+++ b/install-apps.sh
@@ -30,11 +30,16 @@ personal_apps=(
 )
 
 work_apps=(
+    "cloudflare-warp"
     "cursor"
+    "drata-agent"
+    "linear-linear"
     "mongodb-compass" 
     "obsidian"
     "postman"
     "slack"
+    "tandem"
+    "zoom"
 )
 
 # Check if Homebrew is installed


### PR DESCRIPTION
### TL;DR
Added new development tools and work applications to the macOS setup scripts.

### What changed?
- Added MongoDB shell (mongosh) and Graphite to development tools
- Added new work applications:
  - Cloudflare WARP
  - Drata Agent
  - Linear
  - Tandem
  - Zoom

### How to test?
1. Run `dev-tools-setup.sh` to verify mongosh and graphite install correctly
2. Run `install-apps.sh` to verify all new work applications install successfully
3. Launch each new application to ensure they work as expected

### Why make this change?
To include essential tools and applications needed for development workflow and team collaboration in the automated setup process.